### PR TITLE
Switch to using a Sailfish WebView

### DIFF
--- a/qml/pages/Weather3hr.qml
+++ b/qml/pages/Weather3hr.qml
@@ -1,5 +1,7 @@
 import QtQuick 2.5
 import Sailfish.Silica 1.0
+import Sailfish.WebView 1.0
+import Sailfish.WebEngine 1.0
 import harbour.welkweer.Settings 1.0
 
 Page {
@@ -26,39 +28,24 @@ Page {
             visible: isPortrait
         }
     }
-    SilicaWebView {
+    WebView {
         id: webView
-        anchors.top: col.bottom
+        active: visible
+        anchors.verticalCenter: parent.verticalCenter
         anchors.left: parent.left
         anchors.right: parent.right
-        anchors.bottom: parent.bottom
-        url: "https://gadgets.buienradar.nl/gadget/zoommap?lat=" + mainapp.latitude
+        height: Math.ceil(width / 0.703125)
+        url: "https://gadgets.buienradar.nl/gadget/zoommap/?lat=" + mainapp.latitude
              + "&lng=" + mainapp.longitude + "&overname=2&zoom=" + zoomLevel
              + "&naam=" + mainapp.locPlace + "&size=3&voor=1"
-        experimental {
-            transparentBackground: true
-        }
-        experimental.preferences.fullScreenEnabled: true
-        VerticalScrollDecorator {}
-        quickScroll: false
-        experimental.userScripts: [Qt.resolvedUrl("devicePixelRatioHack.js")]
+        privateMode: true
         BusyIndicator {
             anchors.centerIn: parent
             running: webView.loading
             size: BusyIndicatorSize.Large
         }
-        VerticalScrollDecorator {
-            color: Theme.highlightColor // Otherwise we might end up with white decorator on white background
-            width: Theme.paddingSmall // We want to see it properly
-            flickable: webView
-        }
-
-        HorizontalScrollDecorator {
-            // Yeah necessary for larger images and other large sites or zoomed in sites
-            parent: threeHourLocalPage
-            color: Theme.highlightColor // Otherwise we might end up with white decorator on white background
-            height: Theme.paddingSmall // We want to see it properly
-            flickable: webView
+        Component.onCompleted: {
+            WebEngineSettings.cookieBehavior = WebEngineSettings.BlockAll
         }
     }
 }

--- a/rpm/welkweer.spec
+++ b/rpm/welkweer.spec
@@ -23,11 +23,15 @@ Requires:   sailfishsilica-qt5 >= 0.10.9
 Requires:   pyotherside-qml-plugin-python3-qt5 >= 1.5.0
 Requires:   nemo-qml-plugin-contextkit-qt5
 Requires:   sailfish-version >= 4.0.0
+Requires:   sailfish-components-webview-qt5
+Requires:   sailfish-components-webview-qt5-popups
+Requires:   sailfish-components-webview-qt5-pickers
 BuildRequires:  pkgconfig(sailfishapp) >= 1.0.2
 BuildRequires:  pkgconfig(Qt5Core)
 BuildRequires:  pkgconfig(Qt5DBus)
 BuildRequires:  pkgconfig(Qt5Qml)
 BuildRequires:  pkgconfig(Qt5Quick)
+BuildRequires:  pkgconfig(qt5embedwidget) >= 1.14.9
 BuildRequires:  desktop-file-utils
 
 %description


### PR DESCRIPTION
Switches from the deprecated SilicaWebView to the Sailfish WebView.

For some reason the site blocks access if visited multiple times with
cookies enabled, so the WebView is set to have cookies disabled and use
private mode. This seems to allow the page to be viewed.